### PR TITLE
Add family setup screen

### DIFF
--- a/lib/screens/family_setup_page.dart
+++ b/lib/screens/family_setup_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FamilySetupPage extends StatefulWidget {
+  const FamilySetupPage({super.key});
+
+  @override
+  State<FamilySetupPage> createState() => _FamilySetupPageState();
+}
+
+class _FamilySetupPageState extends State<FamilySetupPage> {
+  bool _createMode = false;
+
+  final TextEditingController _searchController = TextEditingController();
+  final TextEditingController _familyNameController = TextEditingController();
+  final TextEditingController _roleController = TextEditingController();
+  final TextEditingController _actorsController = TextEditingController();
+
+  Future<void> _joinFamily() async {
+    final query = _searchController.text.trim();
+    if (query.isEmpty) return;
+    try {
+      await Supabase.instance.client.functions.invoke(
+        'join-family-search',
+        body: {'query': query},
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Request sent')));
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed: $e')));
+      }
+    }
+  }
+
+  Future<void> _createFamily() async {
+    final name = _familyNameController.text.trim();
+    if (name.isEmpty) return;
+    final role = _roleController.text.trim();
+    final actors = _actorsController.text.trim();
+    try {
+      await Supabase.instance.client.functions.invoke(
+        'create-family',
+        body: {
+          'family_name': name,
+          'role': role,
+          'actors': actors.split(',').map((e) => e.trim()).toList(),
+        },
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Family created')));
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Failed: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Family Setup')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ChoiceChip(
+                  label: const Text('Join Existing'),
+                  selected: !_createMode,
+                  onSelected: (_) => setState(() => _createMode = false),
+                ),
+                const SizedBox(width: 16),
+                ChoiceChip(
+                  label: const Text('Create New'),
+                  selected: _createMode,
+                  onSelected: (_) => setState(() => _createMode = true),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            if (!_createMode) ...[
+              TextField(
+                controller: _searchController,
+                decoration: const InputDecoration(
+                  labelText: 'Search families',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _joinFamily,
+                child: const Text('Search'),
+              ),
+            ] else ...[
+              TextField(
+                controller: _familyNameController,
+                decoration: const InputDecoration(
+                  labelText: 'Family name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _roleController,
+                decoration: const InputDecoration(
+                  labelText: 'Your role',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _actorsController,
+                decoration: const InputDecoration(
+                  labelText: 'Actors cared for (comma separated)',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _createFamily,
+                child: const Text('Create Family'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_gate.dart
+++ b/lib/services/auth_gate.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../screens/home_page.dart';
 import '../screens/landing_page.dart';
+import '../screens/family_setup_page.dart';
 
 class AuthGate extends StatefulWidget {
   const AuthGate({super.key});
@@ -12,6 +13,7 @@ class AuthGate extends StatefulWidget {
 
 class _AuthGateState extends State<AuthGate> {
   bool _checkingProfile = false;
+  bool _needsFamilySetup = false;
 
   @override
   void initState() {
@@ -33,7 +35,7 @@ class _AuthGateState extends State<AuthGate> {
     // Check if user exists in our users table
     final existing = await Supabase.instance.client
         .from('users')
-        .select()
+        .select('family_id')
         .eq('id', user.id)
         .maybeSingle();
 
@@ -43,6 +45,9 @@ class _AuthGateState extends State<AuthGate> {
         'id': user.id,
         'email': user.email,
       });
+      _needsFamilySetup = true;
+    } else {
+      _needsFamilySetup = existing['family_id'] == null;
     }
 
     // Insert login_history record
@@ -64,6 +69,8 @@ class _AuthGateState extends State<AuthGate> {
 
     if (session == null) {
       return const LandingPage();
+    } else if (_needsFamilySetup) {
+      return const FamilySetupPage();
     } else {
       return const HomePage();
     }


### PR DESCRIPTION
## Summary
- add `FamilySetupPage` to let users join or create a family
- check for `family_id` after login and show setup page if missing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855415c88e88331adff97728a4f2f71