### PR TITLE
Add email sign-in and unified auth page

### DIFF
--- a/lib/screens/email_auth_page.dart
+++ b/lib/screens/email_auth_page.dart
@@ -1,33 +1,38 @@
 import 'package:flutter/material.dart';
 import '../services/email_auth_service.dart';
 
-class RegistrationPage extends StatefulWidget {
-  const RegistrationPage({super.key});
+class EmailAuthPage extends StatefulWidget {
+  const EmailAuthPage({super.key});
 
   @override
-  State<RegistrationPage> createState() => _RegistrationPageState();
+  State<EmailAuthPage> createState() => _EmailAuthPageState();
 }
 
-class _RegistrationPageState extends State<RegistrationPage> {
+class _EmailAuthPageState extends State<EmailAuthPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _authService = EmailAuthService();
+  bool _signInMode = true;
 
-  Future<void> _register() async {
+  Future<void> _authenticate() async {
     try {
-      final response = await _authService.signUp(
-        _emailController.text,
-        _passwordController.text,
-      );
-
-      if (response.user != null) {
+      final response = _signInMode
+          ? await _authService.signIn(
+              _emailController.text,
+              _passwordController.text,
+            )
+          : await _authService.signUp(
+              _emailController.text,
+              _passwordController.text,
+            );
+      if (!_signInMode && response.user != null) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Confirmation email sent.')),
         );
       }
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Registration failed: $e')),
+        SnackBar(content: Text('Authentication failed: $e')),
       );
     }
   }
@@ -35,7 +40,9 @@ class _RegistrationPageState extends State<RegistrationPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Register with Email')),
+      appBar: AppBar(
+        title: Text(_signInMode ? 'Sign in with Email' : 'Register with Email'),
+      ),
       body: Center(
         child: Container(
           constraints: const BoxConstraints(maxWidth: 800),
@@ -58,8 +65,17 @@ class _RegistrationPageState extends State<RegistrationPage> {
               ),
               const SizedBox(height: 24),
               ElevatedButton(
-                onPressed: _register,
-                child: const Text('Create Account'),
+                onPressed: _authenticate,
+                child: Text(_signInMode ? 'Sign In' : 'Create Account'),
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => setState(() => _signInMode = !_signInMode),
+                child: Text(
+                  _signInMode
+                      ? 'Need an account? Sign up'
+                      : 'Have an account? Sign in',
+                ),
               ),
             ],
           ),

--- a/lib/screens/landing_page.dart
+++ b/lib/screens/landing_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flutter_signin_button/flutter_signin_button.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'registration_page.dart';
+import 'email_auth_page.dart';
 import 'package:gotrue/gotrue.dart';
 
 class LandingPage extends StatelessWidget {
@@ -28,11 +28,11 @@ class LandingPage extends StatelessWidget {
 
 
 
-  /// Navigates to the registration page
-  void _signUpWithEmail(BuildContext context) {
+  /// Navigates to the email auth page
+  void _continueWithEmail(BuildContext context) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => const RegistrationPage()),
+      MaterialPageRoute(builder: (context) => const EmailAuthPage()),
     );
   }
 
@@ -80,9 +80,9 @@ class LandingPage extends StatelessWidget {
                     vertical: 14,
                   ),
                 ),
-                onPressed: () => _signUpWithEmail(context),
+                onPressed: () => _continueWithEmail(context),
                 child: const Text(
-                  'Sign up with Email',
+                  'Continue with Email',
                   style: TextStyle(fontSize: 16),
                 ),
               ),

--- a/lib/services/email_auth_service.dart
+++ b/lib/services/email_auth_service.dart
@@ -6,4 +6,9 @@ class EmailAuthService {
   Future<AuthResponse> signUp(String email, String password) {
     return _client.auth.signUp(email: email, password: password);
   }
+
+  Future<AuthResponse> signIn(String email, String password) {
+    return _client.auth
+        .signInWithPassword(email: email, password: password);
+  }
 }


### PR DESCRIPTION
## Summary
- support email sign-in via `signInWithPassword`
- replace `RegistrationPage` with `EmailAuthPage`
- update landing page button to "Continue with Email" and navigate to `EmailAuthPage`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e481c34948331a3520f6441f0494f