### PR TITLE
Call _checkUserProfile() on auth changes

### DIFF
--- a/lib/services/auth_gate.dart
+++ b/lib/services/auth_gate.dart
@@ -20,6 +20,9 @@ class _AuthGateState extends State<AuthGate> {
     super.initState();
 
     Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+      if (data.session != null) {
+        _checkUserProfile();
+      }
       setState(() {});
     });
 


### PR DESCRIPTION
## Summary
- trigger profile checks in `AuthGate` when the auth session becomes non-null

## Testing
- `./flutter/bin/flutter test -j 1` *(fails: MissingPluginException for shared_preferences)*

------
https://chatgpt.com/codex/tasks/task_e_686e481d2e408331ab36d7a22114e2fe