### PR TITLE
Dispose controllers in RegistrationPage

### DIFF
--- a/lib/screens/family_setup_page.dart
+++ b/lib/screens/family_setup_page.dart
@@ -63,6 +63,15 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
   }
 
   @override
+  void dispose() {
+    _searchController.dispose();
+    _familyNameController.dispose();
+    _roleController.dispose();
+    _actorsController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Family Setup')),

--- a/lib/screens/registration_page.dart
+++ b/lib/screens/registration_page.dart
@@ -33,6 +33,13 @@ class _RegistrationPageState extends State<RegistrationPage> {
   }
 
   @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Register with Email')),


### PR DESCRIPTION
## Summary
- dispose TextEditingControllers in `RegistrationPage`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e481d8c208331a0394d13e599b1a8